### PR TITLE
feat: Create GitHub Pages site for publications

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Publications</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Publications</h1>
+    </header>
+
+    <main>
+        <div class="toolbar">
+            <button id="exportBib">Export as .bib</button>
+            <button id="exportCsv">Export as .csv</button>
+            <button id="exportMd">Export as .md</button>
+        </div>
+        <div id="publicationsList">
+            <!-- Publications will be loaded here by script.js -->
+            <p>Loading publications...</p>
+        </div>
+    </main>
+
+    <footer>
+        <p>Powered by GitHub Pages</p>
+    </footer>
+
+    <script src="script.js"></script></body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,189 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const publicationsList = document.getElementById('publicationsList');
+    const exportBibButton = document.getElementById('exportBib');
+    const exportCsvButton = document.getElementById('exportCsv');
+    const exportMdButton = document.getElementById('exportMd');
+
+    let bibtexData = ''; // To store the raw BibTeX content
+    let parsedEntries = []; // To store parsed BibTeX entries
+
+    // Fetches and processes the BibTeX file
+    async function loadPublications() {
+        try {
+            const response = await fetch('_bibliography/papers.bib');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            bibtexData = await response.text();
+            if (!bibtexData.trim()) {
+                publicationsList.innerHTML = '<p>No publications found in _bibliography/papers.bib. It might be empty or not yet generated.</p>';
+                disableExportButtons(true);
+                return;
+            }
+            parsedEntries = parseBibTeX(bibtexData);
+            displayPublications(parsedEntries);
+            disableExportButtons(false);
+        } catch (error) {
+            console.error('Error loading or parsing BibTeX file:', error);
+            publicationsList.innerHTML = `<p>Error loading publications: ${error.message}. Please check the console for more details.</p>`;
+            disableExportButtons(true);
+        }
+    }
+
+    function disableExportButtons(disable) {
+        exportBibButton.disabled = disable;
+        exportCsvButton.disabled = disable;
+        exportMdButton.disabled = disable;
+    }
+
+    // Basic BibTeX Parser
+    function parseBibTeX(bibtexString) {
+        const entries = [];
+        // Remove comments and split by entry
+        const bibEntries = bibtexString.replace(/%.*\n/g, '').split(/@(?=\w+\s*\{)/);
+
+        bibEntries.forEach(entryStr => {
+            if (!entryStr.trim()) return;
+
+            const entry = {};
+            const firstBrace = entryStr.indexOf('{');
+            const entryTypeMatch = entryStr.substring(0, firstBrace).trim().toLowerCase();
+            entry.type = entryTypeMatch;
+
+            const commaAfterKey = entryStr.indexOf(',', firstBrace);
+            entry.key = entryStr.substring(firstBrace + 1, commaAfterKey).trim();
+
+            const fieldsStr = entryStr.substring(commaAfterKey + 1, entryStr.lastIndexOf('}'));
+
+            // Regex to match field = {value} or field = "value"
+            // This is a simplified parser and might not handle all BibTeX complexities (e.g., nested braces, @string macros)
+            const fieldRegex = /\s*(\w+)\s*=\s*[\{{"]?([^}"{]+)[\}}"}]?,?/g;
+            let match;
+            entry.fields = {};
+
+            while ((match = fieldRegex.exec(fieldsStr)) !== null) {
+                const key = match[1].trim().toLowerCase();
+                let value = match[2].trim();
+                // Basic cleanup: remove extra braces if they are the outer layer
+                if (value.startsWith('{') && value.endsWith('}')) {
+                    value = value.substring(1, value.length - 1);
+                }
+                entry.fields[key] = value.replace(/\s+/g, ' ').replace(/[\n\r]+/g, ' ');
+            }
+            entries.push(entry);
+        });
+        return entries;
+    }
+
+    // Displays publications on the page
+    function displayPublications(entries) {
+        if (!entries || entries.length === 0) {
+            publicationsList.innerHTML = '<p>No publications to display.</p>';
+            return;
+        }
+
+        let html = '<ul>';
+        entries.forEach(entry => {
+            html += '<li>';
+            html += `<h3>${entry.fields.title || 'No Title'}</h3>`;
+            html += `<p><strong>Authors:</strong> ${entry.fields.author || 'N/A'}</p>`;
+            html += `<p><strong>Year:</strong> ${entry.fields.year || 'N/A'}</p>`;
+            if (entry.fields.journal) {
+                html += `<p><strong>Journal:</strong> ${entry.fields.journal}</p>`;
+            }
+            if (entry.fields.booktitle) {
+                html += `<p><strong>Book Title:</strong> ${entry.fields.booktitle}</p>`;
+            }
+            if (entry.fields.howpublished || entry.fields.note) {
+                 html += `<p><strong>Note:</strong> ${entry.fields.howpublished || entry.fields.note}</p>`;
+            }
+            html += `<p><em>Type: ${entry.type}, Key: ${entry.key}</em></p>`;
+            html += '</li>';
+        });
+        html += '</ul>';
+        publicationsList.innerHTML = html;
+    }
+
+    // Export functions
+    function downloadFile(filename, content, mimeType) {
+        const element = document.createElement('a');
+        element.setAttribute('href', `data:${mimeType};charset=utf-8,` + encodeURIComponent(content));
+        element.setAttribute('download', filename);
+        element.style.display = 'none';
+        document.body.appendChild(element);
+        element.click();
+        document.body.removeChild(element);
+    }
+
+    exportBibButton.addEventListener('click', () => {
+        if (bibtexData) {
+            downloadFile('publications.bib', bibtexData, 'application/x-bibtex');
+        } else {
+            alert('BibTeX data not loaded yet.');
+        }
+    });
+
+    exportCsvButton.addEventListener('click', () => {
+        if (parsedEntries.length === 0) {
+            alert('No parsed publications to export.');
+            return;
+        }
+        let csvContent = 'Type,Key,Title,Authors,Year,Journal/Booktitle,DOI,URL\n';
+        parsedEntries.forEach(entry => {
+            const type = entry.type || '';
+            const key = entry.key || '';
+            const title = entry.fields.title || '';
+            const authors = entry.fields.author || '';
+            const year = entry.fields.year || '';
+            const journalOrBooktitle = entry.fields.journal || entry.fields.booktitle || '';
+            const doi = entry.fields.doi || '';
+            const url = entry.fields.url || entry.fields.eprint || '';
+
+            // Basic CSV escaping (wrapping in quotes if it contains comma or quote)
+            const escapeCsv = (val) => {
+                let str = String(val).replace(/"/g, '""'); // escape double quotes
+                if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+                    str = `"${str}"`;
+                }
+                return str;
+            };
+
+            csvContent += `${escapeCsv(type)},${escapeCsv(key)},${escapeCsv(title)},${escapeCsv(authors)},${escapeCsv(year)},${escapeCsv(journalOrBooktitle)},${escapeCsv(doi)},${escapeCsv(url)}\n`;
+        });
+        downloadFile('publications.csv', csvContent, 'text/csv');
+    });
+
+    exportMdButton.addEventListener('click', () => {
+        if (parsedEntries.length === 0) {
+            alert('No parsed publications to export.');
+            return;
+        }
+        let mdContent = '# Publications\n\n';
+        parsedEntries.forEach(entry => {
+            mdContent += `## ${entry.fields.title || 'No Title'}\n\n`;
+            mdContent += `- **Authors:** ${entry.fields.author || 'N/A'}\n`;
+            mdContent += `- **Year:** ${entry.fields.year || 'N/A'}\n`;
+            if (entry.fields.journal) {
+                mdContent += `- **Journal:** ${entry.fields.journal}\n`;
+            }
+            if (entry.fields.booktitle) {
+                mdContent += `- **Book Title:** ${entry.fields.booktitle}\n`;
+            }
+            if (entry.fields.doi) {
+                mdContent += `- **DOI:** [${entry.fields.doi}](https://doi.org/${entry.fields.doi})\n`;
+            }
+            if (entry.fields.url) {
+                mdContent += `- **URL:** [${entry.fields.url}](${entry.fields.url})\n`;
+            }
+             if (entry.fields.eprint) {
+                mdContent += `- **ePrint:** [${entry.fields.eprint}](${entry.fields.eprint})\n`;
+            }
+            mdContent += `- *BibTeX Key: ${entry.key} (${entry.type})*\n\n`;
+            mdContent += '---\n\n';
+        });
+        downloadFile('publications.md', mdContent, 'text/markdown');
+    });
+
+    // Initial load
+    loadPublications();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,92 @@
+body {
+    font-family: Arial, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+header {
+    background: #333;
+    color: #fff;
+    padding: 1rem 0;
+    text-align: center;
+}
+
+header h1 {
+    margin: 0;
+}
+
+main {
+    padding: 1rem;
+    max-width: 800px;
+    margin: 20px auto;
+    background: #fff;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.toolbar {
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #eee;
+    text-align: center;
+}
+
+.toolbar button {
+    background-color: #5cb85c;
+    color: white;
+    border: none;
+    padding: 10px 15px;
+    text-align: center;
+    text-decoration: none;
+    display: inline-block;
+    font-size: 14px;
+    margin: 4px 2px;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.toolbar button:hover {
+    background-color: #4cae4c;
+}
+
+.toolbar button:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+}
+
+#publicationsList ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+#publicationsList li {
+    background: #fff;
+    padding: 15px;
+    margin-bottom: 10px;
+    border-radius: 5px;
+    border: 1px solid #ddd;
+}
+
+#publicationsList h3 {
+    margin-top: 0;
+    color: #337ab7;
+}
+
+#publicationsList p {
+    margin: 5px 0;
+}
+
+#publicationsList p em {
+    font-size: 0.9em;
+    color: #777;
+}
+
+footer {
+    text-align: center;
+    padding: 1rem 0;
+    margin-top: 20px;
+    font-size: 0.9em;
+    color: #777;
+}


### PR DESCRIPTION
Adds an index.html, script.js, and style.css to display publications from _bibliography/papers.bib.

Features:
- Displays publications in a user-friendly format.
- Allows export of the bibliography as .bib, .csv, and .md files.