### PR TITLE
Add .nojekyll to fix 404 error for _bibliography/papers.bib

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,2 @@
+# This file tells GitHub Pages not to run the site through Jekyll.
+# This ensures that directories like _bibliography are served.


### PR DESCRIPTION
This file instructs GitHub Pages to serve underscore-prefixed directories, which should resolve the 404 error when fetching the publications file.