### PR TITLE
feat: Add date filter, URLs, citations, and plot

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -5,6 +5,7 @@
   pages = {1519-1525},
   doi = {10.1093/jac/dkaf095},
   pmid = {40129218},
+  url = {https://doi.org/10.1093/jac/dkaf095},
 }
 
 @article{40036400,
@@ -14,6 +15,7 @@
   pages = {jiaf103},
   doi = {10.1093/infdis/jiaf103},
   pmid = {40036400},
+  url = {https://doi.org/10.1093/infdis/jiaf103},
 }
 
 @article{40133081,
@@ -23,6 +25,7 @@
   pages = {820-823},
   doi = {10.3201/eid3104.241003},
   pmid = {40133081},
+  url = {https://doi.org/10.3201/eid3104.241003},
 }
 
 @article{10.21203/rs.3.rs-4830385/v1,
@@ -30,6 +33,7 @@
   author = {Yagel Y, Motro Y, Green S, Klapper-Goldstein H, Pardo E, Moran-Gilad J, Weintraub AY},
   year = {2024},
   doi = {10.21203/rs.3.rs-4830385/v1},
+  url = {https://doi.org/10.21203/rs.3.rs-4830385/v1},
 }
 
 @article{38811483,
@@ -39,6 +43,7 @@
   pages = {1645-1650},
   doi = {10.1007/s10096-024-04864-1},
   pmid = {38811483},
+  url = {https://doi.org/10.1007/s10096-024-04864-1},
 }
 
 @article{10.22541/au.171030540.05013517/v1,
@@ -46,6 +51,7 @@
   author = {Klapper-Goldstein H, Yagel Y, Motro Y, Green S, Pardo E, Moran-Gilad J, Weintraub A},
   year = {2024},
   doi = {10.22541/au.171030540.05013517/v1},
+  url = {https://doi.org/10.22541/au.171030540.05013517/v1},
 }
 
 @article{38295230,
@@ -55,6 +61,7 @@
   pages = {e135-e138},
   doi = {10.1097/inf.0000000000004237},
   pmid = {38295230},
+  url = {https://doi.org/10.1097/inf.0000000000004237},
 }
 
 @article{40082312,
@@ -64,6 +71,7 @@
   pages = {1649-1656},
   doi = {10.1007/s00404-025-07944-5},
   pmid = {40082312},
+  url = {https://doi.org/10.1007/s00404-025-07944-5},
 }
 
 @article{38042605,
@@ -73,6 +81,8 @@
   pages = {102722},
   doi = {10.1016/j.artmed.2023.102722},
   pmid = {38042605},
+  citations = {1},
+  url = {https://doi.org/10.1016/j.artmed.2023.102722},
 }
 
 @article{37637323,
@@ -82,6 +92,8 @@
   pages = {100393},
   doi = {10.1016/j.jctube.2023.100393},
   pmid = {37637323},
+  citations = {1},
+  url = {https://doi.org/10.1016/j.jctube.2023.100393},
 }
 
 @article{10.21203/rs.3.rs-2555950/v1,
@@ -89,6 +101,7 @@
   author = {Zorea J, Motro Y, Mazor RD, Carmi YK, Shulman Z, Mahajna J, Moran-Gilad J, Elkabets M},
   year = {2023},
   doi = {10.21203/rs.3.rs-2555950/v1},
+  url = {https://doi.org/10.21203/rs.3.rs-2555950/v1},
 }
 
 @article{10.1101/2023.02.09.527814,
@@ -96,6 +109,7 @@
   author = {Zorea J, Motro Y, Mazor RD, Carmi YK, Shulman Z, Mahajna J, Moran-Gilad J, Elkabets M},
   year = {2023},
   doi = {10.1101/2023.02.09.527814},
+  url = {https://doi.org/10.1101/2023.02.09.527814},
 }
 
 @article{39945541,
@@ -105,6 +119,7 @@
   pages = {e0081924},
   doi = {10.1128/msphere.00819-24},
   pmid = {39945541},
+  url = {https://doi.org/10.1128/msphere.00819-24},
 }
 
 @article{10.1101/2022.08.12.503735,
@@ -112,6 +127,7 @@
   author = {Scaturro M, Chierico FD, Motro Y, Chaldoupi A, Flountzi A, Moran-Gilad J, Girolamo A, Koutsiomani T, Krogulska B, Lindsay D, Matuszewska R, Papageorgiou G, Pancer K, Panoussis N, Rota MC, Uldum SA, Velonakis E, Chaput DL, Ricci ML},
   year = {2022},
   doi = {10.1101/2022.08.12.503735},
+  url = {https://doi.org/10.1101/2022.08.12.503735},
 }
 
 @article{38990012,
@@ -121,6 +137,8 @@
   pages = {e0066324},
   doi = {10.1128/aac.00663-24},
   pmid = {38990012},
+  citations = {1},
+  url = {https://doi.org/10.1128/aac.00663-24},
 }
 
 @article{32804993,
@@ -130,6 +148,8 @@
   pages = {303-311},
   doi = {10.1093/bioinformatics/btaa724},
   pmid = {32804993},
+  citations = {4},
+  url = {https://doi.org/10.1093/bioinformatics/btaa724},
 }
 
 @article{33491828,
@@ -139,6 +159,8 @@
   pages = {e12782},
   doi = {10.1111/hel.12782},
   pmid = {33491828},
+  citations = {11},
+  url = {https://doi.org/10.1111/hel.12782},
 }
 
 @article{38411998,
@@ -148,6 +170,8 @@
   pages = {e0330523},
   doi = {10.1128/spectrum.03305-23},
   pmid = {38411998},
+  citations = {5},
+  url = {https://doi.org/10.1128/spectrum.03305-23},
 }
 
 @article{37892571,
@@ -157,6 +181,8 @@
   pages = {6435},
   doi = {10.3390/jcm12206435},
   pmid = {37892571},
+  citations = {1},
+  url = {https://doi.org/10.3390/jcm12206435},
 }
 
 @article{34013863,
@@ -166,6 +192,8 @@
   pages = {1728-1731},
   doi = {10.3201/eid2706.204902},
   pmid = {34013863},
+  citations = {19},
+  url = {https://doi.org/10.3201/eid2706.204902},
 }
 
 @article{37535472,
@@ -174,6 +202,8 @@
   year = {2023},
   doi = {10.2807/1560-7917.es.2023.28.31.2300010},
   pmid = {37535472},
+  citations = {2},
+  url = {https://doi.org/10.2807/1560-7917.es.2023.28.31.2300010},
 }
 
 @article{35451002,
@@ -183,6 +213,8 @@
   pages = {1706-1713},
   doi = {10.1093/cid/ciac281},
   pmid = {35451002},
+  citations = {14},
+  url = {https://doi.org/10.1093/cid/ciac281},
 }
 
 @article{10.1101/793885,
@@ -190,6 +222,7 @@
   author = {Doyle RM, O’Sullivan DM, Aller SD, Bruchmann S, Clark T, Pelegrin AC, Cormican M, Benavente ED, Ellington MJ, McGrath E, Motro Y, Thuy Nguyen TP, Phelan J, Shaw LP, Stabler RA, van Belkum A, van Dorp L, Woodford N, Moran-Gilad J, Huggett JF, Harris KA},
   year = {2019},
   doi = {10.1101/793885},
+  url = {https://doi.org/10.1101/793885},
 }
 
 @article{37115199,
@@ -198,6 +231,8 @@
   year = {2023},
   doi = {10.1099/mgen.0.001014},
   pmid = {37115199},
+  citations = {9},
+  url = {https://doi.org/10.1099/mgen.0.001014},
 }
 
 @article{35336193,
@@ -207,6 +242,8 @@
   pages = {619},
   doi = {10.3390/microorganisms10030619},
   pmid = {35336193},
+  citations = {10},
+  url = {https://doi.org/10.3390/microorganisms10030619},
 }
 
 @article{35883285,
@@ -216,6 +253,7 @@
   pages = {1738},
   doi = {10.3390/ani12141738},
   pmid = {35883285},
+  url = {https://doi.org/10.3390/ani12141738},
 }
 
 @article{35995802,
@@ -225,6 +263,8 @@
   pages = {66},
   doi = {10.1038/s41522-022-00329-5},
   pmid = {35995802},
+  citations = {16},
+  url = {https://doi.org/10.1038/s41522-022-00329-5},
 }
 
 @article{29555344,
@@ -234,6 +274,8 @@
   pages = {275-280},
   doi = {10.1016/j.micinf.2018.02.006},
   pmid = {29555344},
+  citations = {1},
+  url = {https://doi.org/10.1016/j.micinf.2018.02.006},
 }
 
 @article{33374988,
@@ -243,6 +285,8 @@
   pages = {E2},
   doi = {10.3390/microorganisms9010002},
   pmid = {33374988},
+  citations = {22},
+  url = {https://doi.org/10.3390/microorganisms9010002},
 }
 
 @article{37542305,
@@ -252,6 +296,8 @@
   pages = {37},
   doi = {10.1186/s42523-023-00259-3},
   pmid = {37542305},
+  citations = {3},
+  url = {https://doi.org/10.1186/s42523-023-00259-3},
 }
 
 @article{35208693,
@@ -261,6 +307,8 @@
   pages = {238},
   doi = {10.3390/microorganisms10020238},
   pmid = {35208693},
+  citations = {5},
+  url = {https://doi.org/10.3390/microorganisms10020238},
 }
 
 @article{36225741,
@@ -270,6 +318,8 @@
   pages = {ofac482},
   doi = {10.1093/ofid/ofac482},
   pmid = {36225741},
+  citations = {3},
+  url = {https://doi.org/10.1093/ofid/ofac482},
 }
 
 @article{37121997,
@@ -279,6 +329,8 @@
   pages = {107},
   doi = {10.1186/s13046-023-02680-7},
   pmid = {37121997},
+  citations = {5},
+  url = {https://doi.org/10.1186/s13046-023-02680-7},
 }
 
 @article{35057486,
@@ -288,6 +340,8 @@
   pages = {304},
   doi = {10.3390/nu14020304},
   pmid = {35057486},
+  citations = {13},
+  url = {https://doi.org/10.3390/nu14020304},
 }
 
 @article{32294990,
@@ -297,6 +351,8 @@
   pages = {E177},
   doi = {10.3390/antibiotics9040177},
   pmid = {32294990},
+  citations = {9},
+  url = {https://doi.org/10.3390/antibiotics9040177},
 }
 
 @article{32070468,
@@ -305,6 +361,8 @@
   year = {2020},
   doi = {10.2807/1560-7917.es.2020.25.6.1900574},
   pmid = {32070468},
+  citations = {3},
+  url = {https://doi.org/10.2807/1560-7917.es.2020.25.6.1900574},
 }
 
 @article{25078119,
@@ -314,6 +372,8 @@
   pages = {105-120},
   doi = {10.1016/j.freeradbiomed.2014.07.024},
   pmid = {25078119},
+  citations = {44},
+  url = {https://doi.org/10.1016/j.freeradbiomed.2014.07.024},
 }
 
 @article{32855986,
@@ -323,6 +383,8 @@
   pages = {ofaa299},
   doi = {10.1093/ofid/ofaa299},
   pmid = {32855986},
+  citations = {19},
+  url = {https://doi.org/10.1093/ofid/ofaa299},
 }
 
 @article{36576131,
@@ -332,6 +394,8 @@
   pages = {giac122},
   doi = {10.1093/gigascience/giac122},
   pmid = {36576131},
+  citations = {5},
+  url = {https://doi.org/10.1093/gigascience/giac122},
 }
 
 @article{34012005,
@@ -341,6 +405,8 @@
   pages = {10590},
   doi = {10.1038/s41598-021-89881-2},
   pmid = {34012005},
+  citations = {18},
+  url = {https://doi.org/10.1038/s41598-021-89881-2},
 }
 
 @article{28874657,
@@ -350,6 +416,8 @@
   pages = {434},
   doi = {10.1038/s41467-017-00463-1},
   pmid = {28874657},
+  citations = {36},
+  url = {https://doi.org/10.1038/s41467-017-00463-1},
 }
 
 @article{32048983,
@@ -358,6 +426,8 @@
   year = {2020},
   doi = {10.1099/mgen.0.000335},
   pmid = {32048983},
+  citations = {71},
+  url = {https://doi.org/10.1099/mgen.0.000335},
 }
 
 @article{18950961,
@@ -367,6 +437,8 @@
   pages = {340-345},
   doi = {10.1016/j.vetmic.2008.09.051},
   pmid = {18950961},
+  citations = {28},
+  url = {https://doi.org/10.1016/j.vetmic.2008.09.051},
 }
 
 @article{29255684,
@@ -376,6 +448,8 @@
   pages = {1-6},
   doi = {10.1016/j.bdq.2017.10.002},
   pmid = {29255684},
+  citations = {39},
+  url = {https://doi.org/10.1016/j.bdq.2017.10.002},
 }
 
 @article{16773396,
@@ -385,6 +459,8 @@
   pages = {165-185},
   doi = {10.1007/s10142-006-0027-2},
   pmid = {16773396},
+  citations = {101},
+  url = {https://doi.org/10.1007/s10142-006-0027-2},
 }
 
 @article{26879554,
@@ -394,6 +470,8 @@
   pages = {2271-2280},
   doi = {10.1021/acs.jpcb.5b12742},
   pmid = {26879554},
+  citations = {11},
+  url = {https://doi.org/10.1021/acs.jpcb.5b12742},
 }
 
 @article{26876428,
@@ -403,6 +481,8 @@
   pages = {2281-2290},
   doi = {10.1021/acs.jpcb.5b12744},
   pmid = {26876428},
+  citations = {5},
+  url = {https://doi.org/10.1021/acs.jpcb.5b12744},
 }
 
 @article{19262690,
@@ -412,5 +492,7 @@
   pages = {e4641},
   doi = {10.1371/journal.pone.0004641},
   pmid = {19262690},
+  citations = {65},
+  url = {https://doi.org/10.1371/journal.pone.0004641},
 }
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,12 @@
                 <option value="year_oldest">Year (Oldest First)</option>
                 <option value="author_az">First Author (A-Z)</option>
             </select>
+            <label for="filterStartDate">From Year:</label>
+            <input type="number" id="filterStartDate" placeholder="YYYY" min="1900" max="2100">
+            <label for="filterEndDate">To Year:</label>
+            <input type="number" id="filterEndDate" placeholder="YYYY" min="1900" max="2100">
+            <button id="applyFilterButton">Apply Filters</button>
+            <button id="clearFilterButton">Clear Filters</button>
         </div>
         <div id="publicationsList">
             <!-- Publications will be loaded here by script.js -->
@@ -33,5 +39,12 @@
         <p>Powered by GitHub Pages</p>
     </footer>
 
-    <script src="script.js"></script></body>
+    <div class="chart-container" style="width: 80%; margin: 20px auto;">
+        <h2>Citations per Year</h2>
+        <canvas id="citationsPerYearChart"></canvas>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="script.js"></script>
+</body>
 </html>


### PR DESCRIPTION
Implemented several enhancements to the research articles repository:

- Date Filtering: Users can now filter publications by a year range.
- URL Links: Each publication now displays a clickable URL (typically DOI link).
- Citation Counts: The number of citations is displayed for each article where available.
- Citations Per Year Plot: A bar chart shows total citations per year for the currently filtered/displayed publications.

The `fetch_europepmc.py` script was updated to retrieve citation counts and construct URLs, storing them in the `papers.bib` file. The frontend JavaScript (`script.js`) was modified to parse these new fields, implement the filtering logic, display the new information, and render the chart using Chart.js. `index.html` was updated to include date filter inputs and the chart canvas.