### PR TITLE
Refactor: Move plot image to top of webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
         <h1>Publications</h1>
     </header>
 
+    <div class="chart-container" style="width: 80%; margin: 20px auto;">
+        <h2>Publications per Year</h2>
+        <img src="static/publications_per_year.png" alt="Publications per Year Chart" style="width: 100%; height: auto;">
+    </div>
+
     <main>
         <div class="toolbar">
             <button id="exportBib">Export as .bib</button>
@@ -38,11 +43,6 @@
     <footer>
         <p>Powered by GitHub Pages</p>
     </footer>
-
-    <div class="chart-container" style="width: 80%; margin: 20px auto;">
-        <h2>Publications per Year</h2>
-        <img src="static/publications_per_year.png" alt="Publications per Year Chart" style="width: 100%; height: auto;">
-    </div>
 
     <script src="script.js"></script>
 </body>


### PR DESCRIPTION
- Updated index.html to relocate the 'Publications per Year' plot to appear directly after the header and before the main content area.